### PR TITLE
Getting rid of WARNING message on top of the docker' output

### DIFF
--- a/cadence
+++ b/cadence
@@ -2,6 +2,9 @@
 
 if [ "$(uname)" == "Darwin" ]; then
     # Mac OS X
+    
+    # Otherwise we gonna have "The requested image's platform (linux/amd64) does not match the detected host platform..." on Apple Silicon
+    export DOCKER_DEFAULT_PLATFORM=linux/amd64
     docker run -i -t ubercadence/cli:master --address host.docker.internal:7933 --transport tchannel "$@"
   else
     # Linux


### PR DESCRIPTION
Otherwise we have
```
❯ docker run -i -t ubercadence/cli:master --help
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
```
Which is confusing and makes you thinks something's not working.
Especially because the actual output comes next.
